### PR TITLE
Fixed RTCVars header file name in include directive

### DIFF
--- a/src/pvAlgo.cpp
+++ b/src/pvAlgo.cpp
@@ -8,7 +8,7 @@
 #include <loadManager.h>
 #include <mbComm.h>
 #include <pvAlgo.h>
-#include <rtcvars.h>
+#include <RTCVars.h>
 
 
 const uint8_t m = 11;


### PR DESCRIPTION
Hi Stefan, here's the PR to fix the header file name for Linux.