### PR TITLE
Add cfgWifiConnectTimeout + optimize PV-Load-Switch + fix Fronius Smartmeter

### DIFF
--- a/src/button.cpp
+++ b/src/button.cpp
@@ -23,6 +23,16 @@ void btn_setup() {
 		if (cfgBtnDebounce > 0) {
 			btn_PV_SWITCH.attach(PIN_PV_SWITCH, INPUT_PULLUP); // USE INTERNAL PULL-UP
 			btn_PV_SWITCH.interval(cfgBtnDebounce);
+			btn_PV_SWITCH.setPressedState(LOW);
+			btn_PV_SWITCH.update();
+			if (btn_PV_SWITCH.isPressed()) {
+				pv_setMode(PV_ACTIVE);
+			}
+			if (!btn_PV_SWITCH.isPressed()) {
+				pv_setMode(PV_OFF);
+				delay(3000); // if Power loss: Wallbox is booting ~2s slower than WBEC: "lm_storeRequest" would be lost.
+				lm_storeRequest(BOXID, CURR_ABS_MAX);
+			}
 		}
 		// and RST can be used as an output
 		pinMode(PIN_RST, OUTPUT);
@@ -46,5 +56,5 @@ void btn_loop() {
 
 
 boolean btn_getState() {
-	return(btn_PV_SWITCH.pressed());
+	return(btn_PV_SWITCH.isPressed());
 }

--- a/src/globalConfig.cpp
+++ b/src/globalConfig.cpp
@@ -8,7 +8,7 @@
 
 const uint8_t m = 5;
 
-char cfgWbecVersion[]     = "v0.4.5";              // wbec version
+char cfgWbecVersion[]     = "v0.4.5+";              // wbec version
 char cfgBuildDate[]       = __DATE__ " " __TIME__;    // wbec build date
 
 char     cfgApSsid[32];               // SSID of the initial Access Point
@@ -41,6 +41,7 @@ char     cfgInverterIp[16];           // IP address of Inverter, "" to disable
 uint8_t  cfgInverterType;             // 0=off, 1=SolarEdge, 2=Fronius, 3=Kostal
 uint16_t cfgBootlogSize;              // Size of the bootlog buffer for debugging, max. 5000 [bytes]
 uint16_t cfgBtnDebounce;              // Debounce time for button [ms]
+uint16_t cfgWifiConnectTimeout;       // Timeout in seconds to connect to Wifi before change to AP-Mode.
 
 
 static bool createConfig() {
@@ -112,35 +113,36 @@ void loadConfig() {
 		deserializeJson(doc, F("{}"));
 	}
 
-	strncpy(cfgApSsid,          doc["cfgApSsid"]            | "wbec",             sizeof(cfgApSsid));
-	strncpy(cfgApPass,          doc["cfgApPass"]            | "wbec1234",         sizeof(cfgApPass));
-	cfgCntWb                  = doc["cfgCntWb"]             | 1;
-	cfgMbCycleTime            = doc["cfgMbCycleTime"]       | 10; 
-	cfgMbDelay                = doc["cfgMbDelay"]           | 100UL; 
-	cfgMbTimeout              = doc["cfgMbTimeout"]         | 60000UL;
-	cfgStandby                = doc["cfgStandby"]           | 4UL; 
-	strncpy(cfgMqttIp,          doc["cfgMqttIp"]            | "",                 sizeof(cfgMqttIp));
-	cfgMqttPort               = doc["cfgMqttPort"]          | 1883UL;
-	strncpy(cfgMqttUser,        doc["cfgMqttUser"]          | "",                 sizeof(cfgMqttUser));
-	strncpy(cfgMqttPass,        doc["cfgMqttPass"]          | "",                 sizeof(cfgMqttPass));
-	strncpy(cfgNtpServer,       doc["cfgNtpServer"]         | "europe.pool.ntp.org", sizeof(cfgNtpServer));
-	strncpy(cfgFoxUser,         doc["cfgFoxUser"]           | "",                 sizeof(cfgFoxUser));
-	strncpy(cfgFoxPass,         doc["cfgFoxPass"]           | "",                 sizeof(cfgFoxPass));
-	strncpy(cfgFoxDevId,        doc["cfgFoxDevId"]          | "",                 sizeof(cfgFoxDevId));
-	cfgPvActive               = doc["cfgPvActive"]          | 0; 
-	cfgPvCycleTime            = doc["cfgPvCycleTime"]       | 30; 
-	cfgPvLimStart             = doc["cfgPvLimStart"]        | 61; 
-	cfgPvLimStop              = doc["cfgPvLimStop"]         | 50; 
-	cfgPvPhFactor             = doc["cfgPvPhFactor"]        | 69; 
-	cfgPvOffset               = doc["cfgPvOffset"]          | 0UL;
-	cfgTotalCurrMax           = doc["cfgTotalCurrMax"]      | 0UL;
-	cfgHwVersion              = doc["cfgHwVersion"]         | 15;
-	cfgWifiSleepMode          = doc["cfgWifiSleepMode"]     | 0;
-	cfgLoopDelay              = doc["cfgLoopDelay"]         | 255;
-	strncpy(cfgInverterIp,      doc["cfgInverterIp"]        | "",                 sizeof(cfgInverterIp));
-	cfgInverterType           = doc["cfgInverterType"]      | 0;
-	cfgBootlogSize            = doc["cfgBootlogSize"]       | 2000;
-	cfgBtnDebounce            = doc["cfgBtnDebounce"]       | 0;
+	strncpy(cfgApSsid,          doc["cfgApSsid"]             | "wbec",             sizeof(cfgApSsid));
+	strncpy(cfgApPass,          doc["cfgApPass"]             | "wbec1234",         sizeof(cfgApPass));
+	cfgCntWb                  = doc["cfgCntWb"]              | 1;
+	cfgMbCycleTime            = doc["cfgMbCycleTime"]        | 10; 
+	cfgMbDelay                = doc["cfgMbDelay"]            | 100UL; 
+	cfgMbTimeout              = doc["cfgMbTimeout"]          | 60000UL;
+	cfgStandby                = doc["cfgStandby"]            | 4UL; 
+	strncpy(cfgMqttIp,          doc["cfgMqttIp"]             | "",                 sizeof(cfgMqttIp));
+	cfgMqttPort               = doc["cfgMqttPort"]           | 1883UL;
+	strncpy(cfgMqttUser,        doc["cfgMqttUser"]           | "",                 sizeof(cfgMqttUser));
+	strncpy(cfgMqttPass,        doc["cfgMqttPass"]           | "",                 sizeof(cfgMqttPass));
+	strncpy(cfgNtpServer,       doc["cfgNtpServer"]          | "europe.pool.ntp.org", sizeof(cfgNtpServer));
+	strncpy(cfgFoxUser,         doc["cfgFoxUser"]            | "",                 sizeof(cfgFoxUser));
+	strncpy(cfgFoxPass,         doc["cfgFoxPass"]            | "",                 sizeof(cfgFoxPass));
+	strncpy(cfgFoxDevId,        doc["cfgFoxDevId"]           | "",                 sizeof(cfgFoxDevId));
+	cfgPvActive               = doc["cfgPvActive"]           | 0; 
+	cfgPvCycleTime            = doc["cfgPvCycleTime"]        | 30; 
+	cfgPvLimStart             = doc["cfgPvLimStart"]         | 61; 
+	cfgPvLimStop              = doc["cfgPvLimStop"]          | 50; 
+	cfgPvPhFactor             = doc["cfgPvPhFactor"]         | 69; 
+	cfgPvOffset               = doc["cfgPvOffset"]           | 0UL;
+	cfgTotalCurrMax           = doc["cfgTotalCurrMax"]       | 0UL;
+	cfgHwVersion              = doc["cfgHwVersion"]          | 15;
+	cfgWifiSleepMode          = doc["cfgWifiSleepMode"]      | 0;
+	cfgLoopDelay              = doc["cfgLoopDelay"]          | 255;
+	strncpy(cfgInverterIp,      doc["cfgInverterIp"]         | "",                 sizeof(cfgInverterIp));
+	cfgInverterType           = doc["cfgInverterType"]       | 0;
+	cfgBootlogSize            = doc["cfgBootlogSize"]        | 2000;
+	cfgBtnDebounce            = doc["cfgBtnDebounce"]        | 0;
+	cfgWifiConnectTimeout     = doc["cfgWifiConnectTimeout"] | 10;
 	
 	LOG(m, "cfgWbecVersion: %s", cfgWbecVersion);
 	LOG(m, "cfgBuildDate: %s"  , cfgBuildDate);

--- a/src/globalConfig.h
+++ b/src/globalConfig.h
@@ -55,6 +55,8 @@ extern char     cfgInverterIp[16];           // IP address of Inverter, "" to di
 extern uint8_t  cfgInverterType;             // 0=off, 1=SolarEdge, 2=Fronius, 3=Kostal
 extern uint16_t cfgBootlogSize;              // Size of the bootlog buffer for debugging, e.g. 5000 bytes
 extern uint16_t cfgBtnDebounce;              // Debounce time for button [ms]
+extern uint16_t cfgWifiConnectTimeout;       // Timeout in seconds to connect to Wifi before change to AP-Mode.
+
 
 extern void loadConfig();
 

--- a/src/inverter.cpp
+++ b/src/inverter.cpp
@@ -76,6 +76,7 @@ void inverter_loop() {
 			mb.readHreg(remote, REG_SE_M_AC_Power,    (uint16 *) &power_meter,          1, cb, SMARTMETER_SE_ADDRESS);  //Power Zähler
 			mb.readHreg(remote, REG_SE_M_AC_Power_SF, (uint16 *) &power_meter_scale,    1, cb, SMARTMETER_SE_ADDRESS);  //Power Zähler Scale Factor
 		}
+		mb.task();  // Common local Modbus task
 	}
 
 	// Connect and read Fronius
@@ -88,9 +89,10 @@ void inverter_loop() {
 			mb.readHreg(remote,   REG_FR_I_AC_Power_SF, (uint16 *) &power_inverter_scale, 1, cb, INVERTER_FR_ADDRESS);    //Power Inverter Scale Factor
 			mb.readHreg(remote,   REG_FR_M_AC_Power,    (uint16 *) &power_meter,          1, cb, SMARTMETER_FR_ADDRESS);  //Power Zähler
 			mb.readHreg(remote,   REG_FR_M_AC_Power_SF, (uint16 *) &power_meter_scale,    1, cb, SMARTMETER_FR_ADDRESS);  //Power Zähler Scale Factor
-			// Fronius Smartmeter provides the value inverted (pos. = 'Bezug', neg. = 'Einspeisung'), see #24
-			power_meter = -1 * power_meter;
 		}
+		mb.task();  // Common local Modbus task
+		// Fronius Smartmeter provides the value inverted (pos. = 'Bezug', neg. = 'Einspeisung'), see #24
+		power_meter = -1 * power_meter;
 	}
 	
 	// Connect and read Kostal
@@ -104,9 +106,8 @@ void inverter_loop() {
 			mb.readHreg(remote,   REG_KO_M_AC_Power,    (uint16 *) &power_meter,          1, cb, SMARTMETER_KO_ADDRESS);  //Power Zähler
 			mb.readHreg(remote,   REG_KO_M_AC_Power_SF, (uint16 *) &power_meter_scale,    1, cb, SMARTMETER_KO_ADDRESS);  //Power Zähler Scale Factor
 		}
+		mb.task();  // Common local Modbus task
 	}
-
-	mb.task();  // Common local Modbus task
 
 	int16_t pwrInv;
 	int16_t pwrMet;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ void setup() {
   WiFiManager wifiManager;
   char ssid[32]; strcpy(ssid, cfgApSsid);
   char pass[63]; strcpy(pass, cfgApPass);
+  wifiManager.setConnectTimeout(cfgWifiConnectTimeout);
   wifiManager.autoConnect(ssid, pass);
 
   // still experimental (see #12):


### PR DESCRIPTION
- cfgWifiConnectTimeout: konfigurierbare Zeit in der der wbec versucht mit einem WLAN zu verbinden, bevor er selber einen AP erstellt.
- optimize PV-Load-Switch: nun wird beim Bootup (setup) der Eingang ausgelesen, damit dieser immer syncron mit der Website läuft.
- Invertierung des "Fronius Smartmeter Wertes" nachdem "mb.task();" aufgerufen wurde.

Was du davon übernimmst ist natürlich deine sache.
Der Code ist geprüft und funktioniert bei mir (Fronius Symo 17.5 + Fronius Smartmeter)

Einziger bug, der noch enthalten ist:
Die Json Ausgabe /gpio funktioniert noch nicht für D7 (es wird immer D3 angezeigt).