### PR TITLE
Fehler in pvAlgo.cpp und ESP Abstürze mit platformIO ESP8266 Platform v4.1.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:nodemcuv2]
-platform = espressif8266
+platform = espressif8266@4.0.1
 board = nodemcuv2
 framework = arduino
 board_build.filesystem = littlefs

--- a/src/pvAlgo.cpp
+++ b/src/pvAlgo.cpp
@@ -130,7 +130,7 @@ int32_t pv_getWatt() {
 
 
 void pv_setWatt(int32_t val) {
-	if ((watt >= WATT_MIN) && (watt <= WATT_MAX)) {
+	if ((val >= WATT_MIN) && (watt <= WATT_MAX)) {
 			watt = val;
 	}
 }


### PR DESCRIPTION
Bei meinen Tests zu WBEC (v0.4.5) habe ich zwei Probleme festgestellt.
In pvAlgo.cpp ist ein kleiner Fehler enthalten; siehe commit Details.
Unter platformIO mit neuester ESP8266 platform (4.1.0) läßt sich alles wunderbar compilieren. Im Betrieb stürzt der ESP aber bei den meisten Web-Zugriffen ab. Die genaue Ursache ist mir unbekannt, ich vermute sie aber im AsyncWebServer.
Abhilfe schafft hier nur die Plattform in der platformio.ini genau auf die 4.0.1 festzulegen.
Tests mit WBEC v0.4.6 habe ich noch nicht durchführen können da ich mittlerweile zu viele Änderung in den Original-Sourcen vorgenommen habe.