### PR TITLE
Remove address bar on iOS

### DIFF
--- a/data/web.html
+++ b/data/web.html
@@ -7,6 +7,7 @@
 	<meta name="description" content="Heidelberg Wallbox Energy Control">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="stylesheet" href="web.css">
 	<script src="web.js" defer></script>
 


### PR DESCRIPTION
This removes the address bar when using wbec as web app on iOS.