### PR TITLE
Update pvHttp.cpp: fix for "batt" not being read and inverting its value

### DIFF
--- a/src/pvHttp.cpp
+++ b/src/pvHttp.cpp
@@ -63,17 +63,21 @@ void pvHttp_loop() {
 			watt = atol(pch);
 		}
 	}
-
+        LOG(m, "Watt=%d", watt)
+	
 	int32_t batt = 0;
 
 	if (strcmp(cfgPvHttpJsonBatt, "") == 0) {
+			batt = response.toInt();
+	} else {
 		char *pch = strstr(response.c_str(), cfgPvHttpJsonBatt); // search the index of cfgPvHttpJsonBatt, then add it's length
 		if (pch != NULL) {
 			pch += strlen(cfgPvHttpJsonBatt); 
-			batt = atol(pch);  // battery power (pos. = discharging battery, neg. = charging battery)
+			batt = -atol(pch);  // battery power (pos. = discharging battery, neg. = charging battery)
 			watt += batt;      // adding means, that watt will become smaller (=> availPower will become higher), when battery is charging 
 		}
 	}
-	LOG(m, "Watt=%d", watt)
+	LOG(m, "Batt=%d", batt)
+        LOG(m, "Watt+Batt=%d", watt)
 	pv_setWatt(watt);
 }


### PR DESCRIPTION
- the else statement was missing for the cfgPvHttpJsonBatt section, therefore "batt" would only have been evaluated if the parameter was missing in the config...
- Sonnenbatterie reports energy flowing into the batterie (charging) as positive values ("Pac_total_W") while energy flowing into the grid is a positive number ("GridFeedIn_W"). To make sure we give charging the car priority before charging the battery from PV, but also charge the car from PV in case the battery is already full, we need to invert the "batt" value and then add it to "watt".